### PR TITLE
switch to inherits

### DIFF
--- a/R/gbm-internals.R
+++ b/R/gbm-internals.R
@@ -29,7 +29,7 @@
 guessDist <- function(y){
   # If distribution is not given, try to guess it
   if (length(unique(y)) == 2){ d <- "bernoulli" }
-  else if (class(y) == "Surv" ){ d <- "coxph" }
+  else if (inherits(y, "Surv")){ d <- "coxph" }
   else if (is.factor(y)){ d <- "multinomial" }
   else{ d <- "gaussian" }
   cat(paste("Distribution not specified, assuming", d, "...\n"))

--- a/R/gbm.fit.R
+++ b/R/gbm.fit.R
@@ -219,7 +219,7 @@ gbm.fit <- function(x, y, offset = NULL, misc = NULL, distribution = "bernoulli"
   cRows <- nrow(x)
   cCols <- ncol(x)
   
-  if(nrow(x) != ifelse(class(y) == "Surv", nrow(y), length(y))) {
+  if(nrow(x) != ifelse(inherits(y, "Surv"), nrow(y), length(y))) {
     stop("The number of rows in x does not equal the length of y.")
   }
   
@@ -354,7 +354,7 @@ gbm.fit <- function(x, y, offset = NULL, misc = NULL, distribution = "bernoulli"
     Misc <- c(alpha=distribution$alpha)
   }
   if(distribution$name == "coxph") {
-    if(class(y)!="Surv") {
+    if(!inherits(y, "Surv")) {
       stop("Outcome must be a survival object Surv(time,failure)")
     }
     if(attr(y,"type")!="right") {

--- a/R/reconstructGBMdata.R
+++ b/R/reconstructGBMdata.R
@@ -13,7 +13,7 @@
 #' @export
 reconstructGBMdata <- function(x)
 {
-   if(class(x) != "gbm")
+   if(!inherits(x, "gbm"))
    {
       stop( "This function is for use only with objects having class 'gbm'" )
    } else


### PR DESCRIPTION
TLDR: I replaced statements like `class(y) == "Surv"` by the safer `inherits(y, "Surv)`. It's safer, because it handles cases where `class(y)` is a vector of length greater than 1.

In a recent update to `R`, they started triggering warnings when the condition in an `if` statement has length greater than 1, for example:
``` r
foo <- matrix(NA, nrow = 2, ncol = 2)
class(foo)
#> [1] "matrix" "array"
if(class(foo) == "matrix"){
    # Do something
}
#> Warning in if (class(foo) == "matrix") {: the condition has length > 1 and only
#> the first element will be used
#> NULL
```

<sup>Created on 2021-02-03 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>

I've seen a few examples of these in `gbm`, but there's one instance in particular that triggers warnings in the `casebase` package, for which I'm a developer:
``` r
library(casebase)
#> See example usage at http://sahirbhatnagar.com/casebase/
N <- 1000; p <- 30
x <- matrix(rnorm(N * p), N, p)
hx <- exp(x)
ty <- rexp(N, hx)
tcens <- rbinom(n = N,
                prob = 0.3,
                size = 1) # censoring indicator
y <- cbind(time = ty, status = 1 - tcens) # y=Surv(ty,1-tcens) with survival
fitSmoothHazard.fit(x, y, time = "time",
                    event = "status",
                    family = "gbm", ratio = 10)
#> Error in if (nrow(x) != ifelse(class(y) == "Surv", nrow(y), length(y))) {: the condition has length > 1
```

<sup>Created on 2021-02-03 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

(**Note**: It triggers an error on my machine because I turned on a couple flags that CRAN uses to easily find these warnings.)