### PR TITLE
Fix if statement in relative.influence()

### DIFF
--- a/R/relative.influence.R
+++ b/R/relative.influence.R
@@ -72,7 +72,7 @@ relative.influence <- function(object,
       cat( paste( "n.trees not given. Using", n.trees, "trees.\n" ) )
 
    }
-   if (object$distribution == "multinomial") {
+   if (object$distribution$name == "multinomial") {
        n.trees <- n.trees * object$num.classes
    }
    get.rel.inf <- function(obj)


### PR DESCRIPTION
The if statement was raising a warning when distribution is defined as a list (ex: `list(name = "tdist", df = 6)`) for R 4.1 and
before.

The warning became an error since R 4.2+.

Since the name of the distribution is always named, the name is available under `object$distribution$name`.

This closes #57 